### PR TITLE
chore: Export `KeborgCallback` type

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "editor.formatOnSave": true,
+  "prettier.configPath": ".prettierrc.json"
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,12 @@
  * Licensed under the MIT License.
  */
 
-export { Keyborg, KeyborgCallback, createKeyborg, disposeKeyborg } from "./Keyborg";
+export {
+  Keyborg,
+  KeyborgCallback,
+  createKeyborg,
+  disposeKeyborg,
+} from "./Keyborg";
 
 export {
   getLastFocusedProgrammatically,

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-export { Keyborg, createKeyborg, disposeKeyborg } from "./Keyborg";
+export { Keyborg, KeyborgCallback, createKeyborg, disposeKeyborg } from "./Keyborg";
 
 export {
   getLastFocusedProgrammatically,


### PR DESCRIPTION
Fixes #12

This type is necessary for anyone who wants to type a callback to be
compatible with keborg