### PR TITLE
chore: adds .devcontainer to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 dist
 node_modules
+
+# VScode devcontainer
+.devcontainer


### PR DESCRIPTION
Adds `.devcontainer` folder to `.gitignore` to ensure this package has no opinions regarding [dev containers](https://code.visualstudio.com/docs/remote/create-dev-container)