### PR TITLE
fix: Do not trigger keyboard navigation mode when editing text in inputs.

### DIFF
--- a/src/Keyborg.ts
+++ b/src/Keyborg.ts
@@ -236,6 +236,22 @@ class KeyborgCore implements Disposable {
       !isNavigatingWithKeyboard &&
       (!triggerKeys || triggerKeys.has(keyCode))
     ) {
+      const activeElement = this._win?.document.activeElement as
+        | HTMLElement
+        | null
+        | undefined;
+
+      if (
+        activeElement &&
+        (activeElement.tagName === "INPUT" ||
+          activeElement.tagName === "TEXTAREA" ||
+          activeElement.contentEditable === "true")
+      ) {
+        // We're inside an input, textarea or contenteditable, it's not
+        // keyboard navigation, it is text editing scenario.
+        return;
+      }
+
       _state.setVal(true);
     } else if (isNavigatingWithKeyboard && this._dismissKeys?.has(keyCode)) {
       this._scheduleDismiss();


### PR DESCRIPTION
When we're editing text in the text input, it's not keyboard navigation, it's text editing. So, we don't trigger keyboard navigation in that scenario.