### PR TITLE
fix: getLastFocusedProgrammatically returns the element even after the focusin event is processed

### DIFF
--- a/src/FocusEvent.ts
+++ b/src/FocusEvent.ts
@@ -166,9 +166,7 @@ export function disposeFocusEvent(win: Window): void {
 
 /**
  * @param win The window that stores keyborg focus events
- * @returns The last element focused with element.focus(),
- *   or `null` if focus moved without element.focus(),
- *   or `undefined` if Keyborg was not initialized on the window.
+ * @returns The last element focused with element.focus()
  */
 export function getLastFocusedProgrammatically(
   win: Window

--- a/src/FocusEvent.ts
+++ b/src/FocusEvent.ts
@@ -106,7 +106,8 @@ export function setupFocusEvent(win: Window): void {
       if (_canOverrideNativeFocus || data.lastFocusedProgrammatically) {
         details.isFocusedProgrammatically =
           target === data.lastFocusedProgrammatically?.deref();
-
+      }
+      if (!details.isFocusedProgrammatically) {
         data.lastFocusedProgrammatically = undefined;
       }
 
@@ -165,7 +166,9 @@ export function disposeFocusEvent(win: Window): void {
 
 /**
  * @param win The window that stores keyborg focus events
- * @returns The last element focused with element.focus()
+ * @returns The last element focused with element.focus(),
+ *   or `null` if focus moved without element.focus(),
+ *   or `undefined` if Keyborg was not initialized on the window.
  */
 export function getLastFocusedProgrammatically(
   win: Window


### PR DESCRIPTION
## Previous Behavior

Keyborg saves the `lastFocusedProgrammatically` element when `element.focus()` is called, and then clears it when the `focusin` event happens. The result is that the value is cleared before a React app gets the focus event, so there's no reasonable way for the app to call `getLastFocusedProgrammatically` when it has a valid value.

## New Behavior

Only clear the `lastFocusedProgrammatically` value the next time focus changes without `element.focus()` being called. This leaves the value set between focus moves, and keeps its value useful to React apps.
