### PR TITLE
feat: support keyborg focusin event through shadow roots

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -21,7 +21,16 @@ const config = {
   ],
   external: ["tslib"],
   plugins: [
-    typescript(),
+    typescript({
+      tsconfigOverride: {
+        compilerOptions: {
+          // https://github.com/ezolenko/rollup-plugin-typescript2/issues/268
+          emitDeclarationOnly: false,
+          stripInternal: true,
+          sourceMap: true,
+        },
+      },
+    }),
     babel({
       babelHelpers: "bundled",
       extensions,

--- a/src/Keyborg.ts
+++ b/src/Keyborg.ts
@@ -183,7 +183,7 @@ class KeyborgCore implements Disposable {
       return;
     }
 
-    const details = e.details;
+    const details = e.detail;
 
     if (!details.relatedTarget) {
       return;


### PR DESCRIPTION
This PR adds a polyfill to keyborg so that it can detect focus changes within a shadow root.

`focusin` events don't seem to currently bubble out of an open shadow root, so when we detect that focus has moved into a shadow root we add a `focusin` listener to the shadow root to keep dispatching keborg focusin events.