### PR TITLE
chore: downlevel .d.ts files to support older TS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@playwright/test": "^1.40.1",
         "@typescript-eslint/eslint-plugin": "^6.15.0",
         "@typescript-eslint/parser": "^6.15.0",
+        "downlevel-dts": "^0.11.0",
         "eslint": "^8.56.0",
         "eslint-config-prettier": "^8.10.0",
         "eslint-plugin-header": "^3.1.1",
@@ -4822,6 +4823,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/downlevel-dts": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/downlevel-dts/-/downlevel-dts-0.11.0.tgz",
+      "integrity": "sha512-vo835pntK7kzYStk7xUHDifiYJvXxVhUapt85uk2AI94gUUAQX9HNRtrcMHNSc3YHJUEHGbYIGsM99uIbgAtxw==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.3.2",
+        "shelljs": "^0.8.3",
+        "typescript": "next"
+      },
+      "bin": {
+        "downlevel-dts": "index.js"
+      }
+    },
+    "node_modules/downlevel-dts/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/duplexer": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,13 @@
   "main": "./dist/index.js",
   "module": "./dist/esm/index.js",
   "typings": "./dist/index.d.ts",
+  "typesVersions": {
+    "<4.0": {
+      "dist/index.d.ts": [
+        "dist/ts3.9/index.d.ts"
+      ]
+    }
+  },
   "files": [
     "dist"
   ],
@@ -16,7 +23,7 @@
     "url": "git+https://github.com/microsoft/keyborg"
   },
   "scripts": {
-    "build": "tsup",
+    "build": "tsup && npx downlevel-dts ./dist ./dist/ts3.9",
     "bundle-size": "npm run build && monosize measure",
     "format": "prettier --check .",
     "format:fix": "prettier --write .",
@@ -32,6 +39,7 @@
     "@playwright/test": "^1.40.1",
     "@typescript-eslint/eslint-plugin": "^6.15.0",
     "@typescript-eslint/parser": "^6.15.0",
+    "downlevel-dts": "^0.11.0",
     "eslint": "^8.56.0",
     "eslint-config-prettier": "^8.10.0",
     "eslint-plugin-header": "^3.1.1",


### PR DESCRIPTION
Replaces #70.
Fixes #69.

Adds `downlevel-dts` to build process to create type definitions for older TS versions.

### Before 💥 

```ts
declare const version: string | undefined;

export { KEYBORG_FOCUSIN, Keyborg, type KeyborgCallback, type KeyborgFocusInEvent, type KeyborgFocusInEventDetails, createKeyborg, disposeKeyborg, getLastFocusedProgrammatically, nativeFocus, version };
```

```sh
$ tsc --version
Version 3.9.10

$ tsc
node_modules/keyborg/dist/index.d.ts:112:41 - error TS1005: ',' expected.

112 export { KEYBORG_FOCUSIN, Keyborg, type KeyborgCallback, type KeyborgFocusInEvent, type KeyborgFocusInEventDetails, createKeyborg, disposeKeyborg, getLastFocusedProgrammatically, nativeFocus, version };
~~~~~~~~~~~~~~~

    node_modules/keyborg/dist/index.d.ts:112:63 - error TS1005: ',' expected.

112 export { KEYBORG_FOCUSIN, Keyborg, type KeyborgCallback, type KeyborgFocusInEvent, type KeyborgFocusInEventDetails, createKeyborg, disposeKeyborg, getLastFocusedProgrammatically, nativeFocus, version };

```

### After ✅ 

```sh
$ tsc --traceResolution
======== Resolving module 'keyborg' from 'src/index.ts'. ========
'package.json' has 'typings' field './dist/index.d.ts' that references '/Users/olfedias/WebstormProjects/tstest/node_modules/keyborg/dist/index.d.ts'.
'package.json' has a 'typesVersions' entry '<4.0' that matches compiler version '3.9.10', looking for a pattern to match module name 'dist/index.d.ts'.
Module name 'dist/index.d.ts', matched pattern 'dist/index.d.ts'.
Trying substitution 'dist/ts3.9/index.d.ts', candidate module location: 'dist/ts3.9/index.d.ts'
```

```ts
declare const version: string | undefined;
export { KEYBORG_FOCUSIN, Keyborg, KeyborgCallback, KeyborgFocusInEvent, KeyborgFocusInEventDetails, createKeyborg, disposeKeyborg, getLastFocusedProgrammatically, nativeFocus, version };
```

```sh
$ tsc --version
Version 3.9.10

$ yarn tsc
✨  Done in 0.35s.
```