### PR TITLE
feat: Keyborg ids should be unique for multiple bundles

### DIFF
--- a/src/Keyborg.ts
+++ b/src/Keyborg.ts
@@ -279,8 +279,8 @@ export class Keyborg {
   }
 
   private constructor(win: WindowWithKeyborg, props?: KeyborgProps) {
-    this._id = "k" + ++_lastId;
     this._win = win;
+    this._id = this.createId(win);
 
     const current = win.__keyborg;
 
@@ -294,6 +294,25 @@ export class Keyborg {
         refs: { [this._id]: this },
       };
     }
+  }
+
+  /**
+   * creates an id that will be truly global core instance
+   * @returns global id for the keyborg instance
+   */
+  private createId(win: WindowWithKeyborg) {
+    const current = win.__keyborg;
+    let id = "k" + ++_lastId;
+    if (!current) {
+      return id;
+    }
+
+    // other bundles might have created keyborg instances before this one
+    while (current.refs[id]) {
+      id = "k" + ++_lastId;
+    }
+
+    return id;
   }
 
   private dispose(): void {


### PR DESCRIPTION
Currently if a keyborg instance is created from different bundles they will have the same id since the counter is on the file scope.

This PR updates the id generation so that it is unique for a global core instance