### PR TITLE
fix: allows dispatching `keyborg:focusin` on focusable shadow root

### DIFF
--- a/tests/common/ShadowRoot.tsx
+++ b/tests/common/ShadowRoot.tsx
@@ -6,12 +6,13 @@
 import * as React from "react";
 import root from "react-shadow";
 
-export const ShadowRoot: React.FC<{ children: React.ReactNode }> = ({
-  children,
-  ...rest
-}) => {
+export const ShadowRoot: React.FC<{
+  children: React.ReactNode;
+  tabIndex?: number;
+}> = ({ children, tabIndex, ...rest }) => {
   return (
     <root.div
+      tabIndex={tabIndex}
       {...rest}
       style={{
         border: "2px solid magenta",

--- a/tests/focus-in-event.spec.ts
+++ b/tests/focus-in-event.spec.ts
@@ -66,3 +66,55 @@ test("behavior in shadow roots", async ({ page }) => {
     "focus-visible",
   );
 });
+
+test("behavior in focusable shadow roots", async ({ page }) => {
+  await page.goto("/?story=focus-in-event--nested-focusable-shadow-roots");
+
+  // Click the button [nav by mouse in light DOM]
+  await page.getByText("Light DOM: Button A").click();
+  await expect(await page.getByText("Light DOM: Button A")).not.toHaveClass(
+    "focus-visible",
+  );
+
+  // Press Tab [nav by keyboard to focusable shadow root]
+  await page.keyboard.press("Tab");
+  await expect(await page.getByTestId("focusable-shadow-root-l1")).toHaveClass(
+    "focus-visible",
+  );
+
+  // Press Tab [nav by keyboard to nested shadow root]
+  await page.keyboard.press("Tab");
+  await expect(await page.getByText("Shadow DOM: Button B")).toHaveClass(
+    "focus-visible",
+  );
+
+  // Press Tab [nav by keyboard to focusable nested shadow root]
+  await page.keyboard.press("Tab");
+  await expect(await page.getByText("Shadow DOM: Button C")).toHaveClass(
+    "focus-visible",
+  );
+
+  // Press Tab [nav by keyboard to nested shadow root]
+  await page.keyboard.press("Tab");
+  await expect(await page.getByTestId("focusable-shadow-root-l3")).toHaveClass(
+    "focus-visible",
+  );
+
+  // Press Shift+Tab [nav back by keyboard to nested shadow root]
+  await page.keyboard.press("Shift+Tab");
+  await expect(await page.getByText("Shadow DOM: Button C")).toHaveClass(
+    "focus-visible",
+  );
+
+  // Press Shift+Tab [nav back by keyboard to nested shadow root]
+  await page.keyboard.press("Shift+Tab");
+  await expect(await page.getByText("Shadow DOM: Button B")).toHaveClass(
+    "focus-visible",
+  );
+
+  // Press Shift+Tab [nav back by keyboard to shadow root]
+  await page.keyboard.press("Shift+Tab");
+  await expect(await page.getByTestId("focusable-shadow-root-l1")).toHaveClass(
+    "focus-visible",
+  );
+});

--- a/tests/focus-in-event.stories.tsx
+++ b/tests/focus-in-event.stories.tsx
@@ -118,3 +118,32 @@ export const NestedShadowRoots = () => (
     </FocusInListener>
   </div>
 );
+
+export const NestedFocusableShadowRoots = () => (
+  <div style={{ display: "flex", flexDirection: "column", gap: 20 }}>
+    <FocusInListener>
+      <div
+        style={{
+          border: "2px solid blue",
+          display: "flex",
+          gap: 5,
+          padding: 20,
+        }}
+      >
+        <button>Light DOM: Button A</button>
+      </div>
+
+      <ShadowRoot data-testid="focusable-shadow-root-l1" tabIndex={0}>
+        <button>Shadow DOM: Button B</button>
+
+        <ShadowRoot data-testid="shadow-root-l2">
+          <button>Shadow DOM: Button C</button>
+
+          <ShadowRoot data-testid="focusable-shadow-root-l3" tabIndex={0}>
+            <span>Without focusable child</span>
+          </ShadowRoot>
+        </ShadowRoot>
+      </ShadowRoot>
+    </FocusInListener>
+  </div>
+);


### PR DESCRIPTION
Keyborg doesn't dispatch `keyborg:focusin` for shadow roots when they get focus. Web components - e.g. fluent-button from [Fluent UI Web Components](https://github.com/microsoft/fluentui/tree/web-components-v3) - don't get `keyborg:focusin` dispatched for them because of that. The proposed fix lets `keyborg:focusin` event be dispatched for focused shadow root.

When focus goes back from element in shadow DOM to focusable shadow root (Shift+Tab), there's no `focusin` event dispatched for shadow root. The second part of the fix calls `onFocusIn` from `focusOutHandler` if `relatedTarget` of blur event is shadow root and it contains target element in its shadow DOM.

