### PR TITLE
fix: use unique IDs to prevent instance collisions across bundles

### DIFF
--- a/src/Keyborg.mts
+++ b/src/Keyborg.mts
@@ -18,7 +18,17 @@ interface WindowWithKeyborg extends Window {
   };
 }
 
-let _lastId = 0;
+function generateId(): string {
+  const arr = new Uint8Array(16);
+  crypto.getRandomValues(arr);
+
+  let id = "";
+  for (let i = 0; i < arr.length; i++) {
+    id += arr[i].toString(16).padStart(2, "0");
+  }
+
+  return id;
+}
 
 export type KeyborgCallback = (isNavigatingWithKeyboard: boolean) => void;
 
@@ -215,7 +225,7 @@ function createKeyborgCore(targetWindow: WindowWithKeyborg): KeyborgCoreHandle {
 
 export function createKeyborg(win: Window): Keyborg {
   const kwin = win as WindowWithKeyborg;
-  const id = "k" + ++_lastId;
+  const id = generateId();
   let localWin: WindowWithKeyborg | undefined = kwin;
   let core: KeyborgCoreHandle | undefined;
   // `callbacks` is exposed as `instance._cb` to satisfy the slot wire


### PR DESCRIPTION
## Summary
- Replaces the module-scoped `_lastId` counter with `crypto.getRandomValues()` to generate unique instance IDs
- When multiple bundles include keyborg on the same page, they each had their own `_lastId` starting at 0, causing ID collisions in the shared `window.__keyborg.refs` map
- With random IDs, each instance is guaranteed unique regardless of how many bundles coexist
- Uses `crypto.getRandomValues()` (not `crypto.randomUUID()`) to support Edge 84+, Firefox 75+, Chrome 84+, Safari 14.1+

Closes #99
Supersedes #75 and #104

## Test plan
- [x] `npm run build` passes
- [x] `npm run lint` passes
- [x] All existing Playwright tests pass (10/10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)