### PR TITLE
devops: switch to @tony.ganchev/eslint-plugin-header

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,11 +1,8 @@
 import eslint from "@eslint/js";
 import tseslint from "typescript-eslint";
 import eslintConfigPrettier from "eslint-config-prettier";
-import header from "eslint-plugin-header";
+import header from "@tony.ganchev/eslint-plugin-header";
 import importPlugin from "eslint-plugin-import";
-
-// https://github.com/Stuk/eslint-plugin-header/issues/57#issuecomment-2378485611
-header.rules.header.meta.schema = false;
 
 export default tseslint.config(
   {
@@ -37,14 +34,20 @@ export default tseslint.config(
       "guard-for-in": "error",
       "header/header": [
         1,
-        "block",
-        [
-          "!",
-          " * Copyright (c) Microsoft Corporation. All rights reserved.",
-          " * Licensed under the MIT License.",
-          " ",
-        ],
-        1,
+        {
+          header: {
+            commentType: "block",
+            lines: [
+              "!",
+              " * Copyright (c) Microsoft Corporation. All rights reserved.",
+              " * Licensed under the MIT License.",
+              " ",
+            ],
+          },
+          trailingEmptyLines: {
+            minimum: 1
+          }
+        }
       ],
       "id-denylist": "off",
       "id-match": "off",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,12 +11,12 @@
       "devDependencies": {
         "@playwright/test": "^1.58.2",
         "@storybook/react-vite": "^10.2.14",
+        "@tony.ganchev/eslint-plugin-header": "^3.2.4",
         "@types/react": "^18.3.28",
         "@types/react-dom": "^18.3.7",
         "downlevel-dts": "^0.11.0",
         "eslint": "^9.39.3",
         "eslint-config-prettier": "^10.1.8",
-        "eslint-plugin-header": "^3.1.1",
         "eslint-plugin-import": "^2.32.0",
         "monosize": "^0.8.0",
         "monosize-bundler-webpack": "^0.3.1",
@@ -2761,6 +2761,16 @@
         "@testing-library/dom": ">=7.21.4"
       }
     },
+    "node_modules/@tony.ganchev/eslint-plugin-header": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@tony.ganchev/eslint-plugin-header/-/eslint-plugin-header-3.2.4.tgz",
+      "integrity": "sha512-zqMKTW/KQmqKGINkhwEPoJFcJ0ewUkUAmvzHLB5N+n/6bsk7D/xkQ50VhUakG2P4JHHtqsncaXrPxgSeuBPmOw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "eslint": ">=7.7.0"
+      }
+    },
     "node_modules/@tootallnate/quickjs-emscripten": {
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
@@ -5017,16 +5027,6 @@
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.1"
-      }
-    },
-    "node_modules/eslint-plugin-header": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-header/-/eslint-plugin-header-3.1.1.tgz",
-      "integrity": "sha512-9vlKxuJ4qf793CmeeSrZUvVClw6amtpghq3CuWcB5cUNnWHQhgcqy5eF8oVKFk1G3Y/CbchGfEaw3wiIJaNmVg==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "eslint": ">=7.7.0"
       }
     },
     "node_modules/eslint-plugin-import": {

--- a/package.json
+++ b/package.json
@@ -46,12 +46,12 @@
   "devDependencies": {
     "@playwright/test": "^1.58.2",
     "@storybook/react-vite": "^10.2.14",
+    "@tony.ganchev/eslint-plugin-header": "^3.2.4",
     "@types/react": "^18.3.28",
     "@types/react-dom": "^18.3.7",
     "downlevel-dts": "^0.11.0",
     "eslint": "^9.39.3",
     "eslint-config-prettier": "^10.1.8",
-    "eslint-plugin-header": "^3.1.1",
     "eslint-plugin-import": "^2.32.0",
     "monosize": "^0.8.0",
     "monosize-bundler-webpack": "^0.3.1",


### PR DESCRIPTION
Reasons:
- The fork is supported and updated.
- ESLint 9-native with full schema support and needing no hacks.
- Windows support
- Multiple other bugfixes.
- UX improvements - better error messages and more autofix capabilities.
- Extensive documentation.
- Better configuration format (although the old one is still supported).