### PR TITLE
perf: raise build target to ES2022

### DIFF
--- a/tsdown.config.mts
+++ b/tsdown.config.mts
@@ -4,7 +4,7 @@ import pkg from "./package.json";
 export default defineConfig({
   entry: ["src/index.mts"],
   format: ["cjs", "es"],
-  target: "es2019",
+  target: "es2022",
 
   env: {
     PKG_VERSION: pkg.version,


### PR DESCRIPTION
## Summary

- Flips `target` in `tsdown.config.mts` from `es2019` to `es2022`. At ES2022, class fields, private identifiers, optional chaining, and nullish coalescing are emitted natively instead of being transpiled into helpers.
- `downlevel-dts` is unaffected: it only rewrites emitted `.d.ts` files and does not see the runtime target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)