### PR TITLE
perf: shrink bundle via listener helpers and shorter internal names

### DIFF
--- a/src/FocusEvent.mts
+++ b/src/FocusEvent.mts
@@ -2,21 +2,24 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
+import { off, on } from "./dom.mts";
+
 export const KEYBORG_FOCUSIN = "keyborg:focusin";
 export const KEYBORG_FOCUSOUT = "keyborg:focusout";
 
 interface KeyborgFocus {
-  /**
-   * This is the native `focus` function that is retained so that it can be restored when keyborg is disposed
-   */
-  __keyborgNativeFocus?: (options?: FocusOptions | undefined) => void;
+  // Retained so the native `focus` can be restored when keyborg is disposed.
+  // Short key — internal, never read by any external consumer.
+  _n?: (options?: FocusOptions | undefined) => void;
 }
 
+// Internal data bag stored on `window.__keyborgData`. Keys are abbreviated:
+// nothing outside this module reads them, so shortening them is free bytes.
 interface KeyborgFocusEventData {
-  focusInHandler: (e: FocusEvent) => void;
-  focusOutHandler: (e: FocusEvent) => void;
-  lastFocusedProgrammatically?: WeakRef<HTMLElement>;
-  shadowTargets: Set<WeakRef<ShadowRoot>>;
+  _fi: EventListener;
+  _fo: EventListener;
+  _lfp?: WeakRef<HTMLElement>;
+  _st: Set<WeakRef<ShadowRoot>>;
 }
 
 /**
@@ -54,7 +57,8 @@ export interface KeyborgFocusInEventDetails {
   originalEvent?: FocusEvent;
 }
 
-export interface KeyborgFocusInEvent extends CustomEvent<KeyborgFocusInEventDetails> {
+export interface KeyborgFocusInEvent
+  extends CustomEvent<KeyborgFocusInEventDetails> {
   /**
    * @deprecated - used `event.detail`
    */
@@ -73,8 +77,8 @@ export type KeyborgFocusOutEvent = CustomEvent<KeyborgFocusOutEventDetails>;
 export function nativeFocus(element: HTMLElement): void {
   const focus = element.focus as KeyborgFocus;
 
-  if (focus.__keyborgNativeFocus) {
-    focus.__keyborgNativeFocus.call(element);
+  if (focus._n) {
+    focus._n.call(element);
   } else {
     element.focus();
   }
@@ -85,24 +89,26 @@ export function nativeFocus(element: HTMLElement): void {
  */
 export function setupFocusEvent(win: Window): void {
   const kwin = win as WindowWithKeyborgFocusEvent;
+  const doc = kwin.document;
+  const proto = kwin.HTMLElement.prototype;
 
   if (!_canOverrideNativeFocus) {
     _canOverrideNativeFocus = canOverrideNativeFocus(kwin);
   }
 
-  const origFocus = kwin.HTMLElement.prototype.focus;
+  const origFocus = proto.focus;
 
-  if ((origFocus as KeyborgFocus).__keyborgNativeFocus) {
+  if ((origFocus as KeyborgFocus)._n) {
     // Already set up.
     return;
   }
 
-  kwin.HTMLElement.prototype.focus = focus;
+  proto.focus = focus;
 
   const shadowTargets: Set<WeakRef<ShadowRoot>> = new Set();
 
-  const focusOutHandler = (e: FocusEvent) => {
-    const target = e.target as HTMLElement;
+  const focusOutHandler: EventListener = (e) => {
+    const target = (e as FocusEvent).target as HTMLElement;
 
     if (!target) {
       return;
@@ -114,21 +120,22 @@ export function setupFocusEvent(win: Window): void {
       // Allows the event to bubble past an open shadow root
       composed: true,
       detail: {
-        originalEvent: e,
+        originalEvent: e as FocusEvent,
       },
     });
 
     target.dispatchEvent(event);
   };
 
-  const focusInHandler = (e: FocusEvent) => {
-    const target = e.target as HTMLElement;
+  const focusInHandler: EventListener = (e) => {
+    const focusEvent = e as FocusEvent;
+    const target = focusEvent.target as HTMLElement;
 
     if (!target) {
       return;
     }
 
-    let node: Node | null | undefined = e.composedPath()[0] as
+    let node: Node | null | undefined = focusEvent.composedPath()[0] as
       | Node
       | null
       | undefined;
@@ -151,13 +158,16 @@ export function setupFocusEvent(win: Window): void {
         shadowTargets.delete(shadowRootWeakRef);
 
         if (shadowRoot) {
-          shadowRoot.removeEventListener("focusin", focusInHandler, true);
-          shadowRoot.removeEventListener("focusout", focusOutHandler, true);
+          off(shadowRoot, "focusin", focusInHandler);
+          off(shadowRoot, "focusout", focusOutHandler);
         }
       }
     }
 
-    onFocusIn(target, (e.relatedTarget as HTMLElement | null) || undefined);
+    onFocusIn(
+      target,
+      (focusEvent.relatedTarget as HTMLElement | null) || undefined,
+    );
   };
 
   const onFocusIn = (
@@ -179,41 +189,6 @@ export function setupFocusEvent(win: Window): void {
        * Each shadow root encounter requires a new capture listener.
        * Why capture? - we want to follow the focus event in order or descending nested shadow roots
        * When there are no more shadow root targets - dispatch the keyborg:focusin event
-       *
-       * 1. no focus event
-       * > document - capture listener ✅
-       *   > shadow root 1
-       *     > shadow root 2
-       *       > shadow root 3
-       *         > focused element
-       *
-       * 2. focus event received by document listener
-       * > document - capture listener ✅ (focus event here)
-       *   > shadow root 1 - capture listener ✅
-       *     > shadow root 2
-       *       > shadow root 3
-       *         > focused element
-
-       * 3. focus event received by root l1 listener
-       * > document - capture listener ✅
-       *   > shadow root 1 - capture listener ✅ (focus event here)
-       *     > shadow root 2 - capture listener ✅
-       *       > shadow root 3
-       *         > focused element
-       *
-       * 4. focus event received by root l2 listener
-       * > document - capture listener ✅
-       *   > shadow root 1 - capture listener ✅
-       *     > shadow root 2 - capture listener ✅ (focus event here)
-       *       > shadow root 3 - capture listener ✅
-       *         > focused element
-       *
-       * 5. focus event received by root l3 listener, no more shadow root targets
-       * > document - capture listener ✅
-       *   > shadow root 1 - capture listener ✅
-       *     > shadow root 2 - capture listener ✅
-       *       > shadow root 3 - capture listener ✅ (focus event here)
-       *         > focused element ✅ (no shadow root - dispatch keyborg event)
        */
 
       for (const shadowRootWeakRef of shadowTargets) {
@@ -222,8 +197,8 @@ export function setupFocusEvent(win: Window): void {
         }
       }
 
-      shadowRoot.addEventListener("focusin", focusInHandler, true);
-      shadowRoot.addEventListener("focusout", focusOutHandler, true);
+      on(shadowRoot, "focusin", focusInHandler);
+      on(shadowRoot, "focusout", focusOutHandler);
 
       shadowTargets.add(new WeakRef(shadowRoot));
 
@@ -246,47 +221,36 @@ export function setupFocusEvent(win: Window): void {
     // Tabster (and other users) can still use the legacy details field - keeping for backwards compat
     event.details = details;
 
-    if (_canOverrideNativeFocus || data.lastFocusedProgrammatically) {
-      details.isFocusedProgrammatically =
-        target === data.lastFocusedProgrammatically?.deref();
+    if (_canOverrideNativeFocus || data._lfp) {
+      details.isFocusedProgrammatically = target === data._lfp?.deref();
 
-      data.lastFocusedProgrammatically = undefined;
+      data._lfp = undefined;
     }
 
     target.dispatchEvent(event);
   };
 
   const data: KeyborgFocusEventData = (kwin.__keyborgData = {
-    focusInHandler,
-    focusOutHandler,
-    shadowTargets,
+    _fi: focusInHandler,
+    _fo: focusOutHandler,
+    _st: shadowTargets,
   });
 
-  kwin.document.addEventListener(
-    "focusin",
-    kwin.__keyborgData.focusInHandler,
-    true,
-  );
-
-  kwin.document.addEventListener(
-    "focusout",
-    kwin.__keyborgData.focusOutHandler,
-    true,
-  );
+  on(doc, "focusin", focusInHandler);
+  on(doc, "focusout", focusOutHandler);
 
   function focus(this: HTMLElement) {
-    const keyborgNativeFocusEvent = (kwin as WindowWithKeyborgFocusEvent)
-      .__keyborgData;
+    const d = (kwin as WindowWithKeyborgFocusEvent).__keyborgData;
 
-    if (keyborgNativeFocusEvent) {
-      keyborgNativeFocusEvent.lastFocusedProgrammatically = new WeakRef(this);
+    if (d) {
+      d._lfp = new WeakRef(this);
     }
 
     // eslint-disable-next-line prefer-rest-params
     return origFocus.apply(this, arguments);
   }
 
-  let activeElement = kwin.document.activeElement as Element | null;
+  let activeElement = doc.activeElement as Element | null;
 
   // If keyborg is created with the focus inside shadow root, we need
   // to go through the shadows up to make sure all relevant shadows
@@ -296,7 +260,7 @@ export function setupFocusEvent(win: Window): void {
     activeElement = activeElement.shadowRoot.activeElement;
   }
 
-  (focus as KeyborgFocus).__keyborgNativeFocus = origFocus;
+  (focus as KeyborgFocus)._n = origFocus;
 }
 
 /**
@@ -306,40 +270,23 @@ export function setupFocusEvent(win: Window): void {
 export function disposeFocusEvent(win: Window): void {
   const kwin = win as WindowWithKeyborgFocusEvent;
   const proto = kwin.HTMLElement.prototype;
-  const origFocus = (proto.focus as KeyborgFocus).__keyborgNativeFocus;
-  const keyborgNativeFocusEvent = kwin.__keyborgData;
+  const origFocus = (proto.focus as KeyborgFocus)._n;
+  const data = kwin.__keyborgData;
 
-  if (keyborgNativeFocusEvent) {
-    kwin.document.removeEventListener(
-      "focusin",
-      keyborgNativeFocusEvent.focusInHandler,
-      true,
-    );
+  if (data) {
+    off(kwin.document, "focusin", data._fi);
+    off(kwin.document, "focusout", data._fo);
 
-    kwin.document.removeEventListener(
-      "focusout",
-      keyborgNativeFocusEvent.focusOutHandler,
-      true,
-    );
-
-    for (const shadowRootWeakRef of keyborgNativeFocusEvent.shadowTargets) {
+    for (const shadowRootWeakRef of data._st) {
       const shadowRoot = shadowRootWeakRef.deref();
 
       if (shadowRoot) {
-        shadowRoot.removeEventListener(
-          "focusin",
-          keyborgNativeFocusEvent.focusInHandler,
-          true,
-        );
-        shadowRoot.removeEventListener(
-          "focusout",
-          keyborgNativeFocusEvent.focusOutHandler,
-          true,
-        );
+        off(shadowRoot, "focusin", data._fi);
+        off(shadowRoot, "focusout", data._fo);
       }
     }
 
-    keyborgNativeFocusEvent.shadowTargets.clear();
+    data._st.clear();
 
     delete kwin.__keyborgData;
   }
@@ -356,10 +303,7 @@ export function disposeFocusEvent(win: Window): void {
 export function getLastFocusedProgrammatically(
   win: Window,
 ): HTMLElement | null | undefined {
-  const keyborgNativeFocusEvent = (win as WindowWithKeyborgFocusEvent)
-    .__keyborgData;
+  const data = (win as WindowWithKeyborgFocusEvent).__keyborgData;
 
-  return keyborgNativeFocusEvent
-    ? keyborgNativeFocusEvent.lastFocusedProgrammatically?.deref() || null
-    : undefined;
+  return data ? data._lfp?.deref() || null : undefined;
 }

--- a/src/FocusEvent.mts
+++ b/src/FocusEvent.mts
@@ -9,9 +9,10 @@ export const KEYBORG_FOCUSIN = "keyborg:focusin";
 export const KEYBORG_FOCUSOUT = "keyborg:focusout";
 
 interface KeyborgFocus {
-  // Retained so the native `focus` can be restored when keyborg is disposed.
-  // Short key — internal, never read by any external consumer.
-  _n?: (options?: FocusOptions | undefined) => void;
+  /**
+   * This is the native `focus` function that is retained so that it can be restored when keyborg is disposed
+   */
+  __keyborgNativeFocus?: (options?: FocusOptions | undefined) => void;
 }
 
 // Internal data stored on `window.__keyborgData` as a tuple. Nothing outside
@@ -82,8 +83,8 @@ export type KeyborgFocusOutEvent = CustomEvent<KeyborgFocusOutEventDetails>;
 export function nativeFocus(element: HTMLElement): void {
   const focus = element.focus as KeyborgFocus;
 
-  if (focus._n) {
-    focus._n.call(element);
+  if (focus.__keyborgNativeFocus) {
+    focus.__keyborgNativeFocus.call(element);
   } else {
     element.focus();
   }
@@ -103,7 +104,7 @@ export function setupFocusEvent(win: Window): void {
 
   const origFocus = proto.focus;
 
-  if ((origFocus as KeyborgFocus)._n) {
+  if ((origFocus as KeyborgFocus).__keyborgNativeFocus) {
     // Already set up.
     return;
   }
@@ -190,6 +191,41 @@ export function setupFocusEvent(win: Window): void {
        * Each shadow root encounter requires a new capture listener.
        * Why capture? - we want to follow the focus event in order or descending nested shadow roots
        * When there are no more shadow root targets - dispatch the keyborg:focusin event
+       *
+       * 1. no focus event
+       * > document - capture listener ✅
+       *   > shadow root 1
+       *     > shadow root 2
+       *       > shadow root 3
+       *         > focused element
+       *
+       * 2. focus event received by document listener
+       * > document - capture listener ✅ (focus event here)
+       *   > shadow root 1 - capture listener ✅
+       *     > shadow root 2
+       *       > shadow root 3
+       *         > focused element
+       *
+       * 3. focus event received by root l1 listener
+       * > document - capture listener ✅
+       *   > shadow root 1 - capture listener ✅ (focus event here)
+       *     > shadow root 2 - capture listener ✅
+       *       > shadow root 3
+       *         > focused element
+       *
+       * 4. focus event received by root l2 listener
+       * > document - capture listener ✅
+       *   > shadow root 1 - capture listener ✅
+       *     > shadow root 2 - capture listener ✅ (focus event here)
+       *       > shadow root 3 - capture listener ✅
+       *         > focused element
+       *
+       * 5. focus event received by root l3 listener, no more shadow root targets
+       * > document - capture listener ✅
+       *   > shadow root 1 - capture listener ✅
+       *     > shadow root 2 - capture listener ✅
+       *       > shadow root 3 - capture listener ✅ (focus event here)
+       *         > focused element ✅ (no shadow root - dispatch keyborg event)
        */
 
       for (const shadowRootWeakRef of shadowTargets) {
@@ -263,7 +299,7 @@ export function setupFocusEvent(win: Window): void {
     activeElement = activeElement.shadowRoot.activeElement;
   }
 
-  (focus as KeyborgFocus)._n = origFocus;
+  (focus as KeyborgFocus).__keyborgNativeFocus = origFocus;
 }
 
 /**
@@ -273,7 +309,7 @@ export function setupFocusEvent(win: Window): void {
 export function disposeFocusEvent(win: Window): void {
   const kwin = win as WindowWithKeyborgFocusEvent;
   const proto = kwin.HTMLElement.prototype;
-  const origFocus = (proto.focus as KeyborgFocus)._n;
+  const origFocus = (proto.focus as KeyborgFocus).__keyborgNativeFocus;
   const data = kwin.__keyborgData;
 
   if (data) {

--- a/src/FocusEvent.mts
+++ b/src/FocusEvent.mts
@@ -2,7 +2,8 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License.
  */
-import { off, on } from "./dom.mts";
+
+import { addEventListener, removeEventListener } from "./dom.mts";
 
 export const KEYBORG_FOCUSIN = "keyborg:focusin";
 export const KEYBORG_FOCUSOUT = "keyborg:focusout";
@@ -13,14 +14,19 @@ interface KeyborgFocus {
   _n?: (options?: FocusOptions | undefined) => void;
 }
 
-// Internal data bag stored on `window.__keyborgData`. Keys are abbreviated:
-// nothing outside this module reads them, so shortening them is free bytes.
-interface KeyborgFocusEventData {
-  _fi: EventListener;
-  _fo: EventListener;
-  _lfp?: WeakRef<HTMLElement>;
-  _st: Set<WeakRef<ShadowRoot>>;
-}
+// Internal data stored on `window.__keyborgData` as a tuple. Nothing outside
+// this module reads these slots, so a tuple drops the property-name strings
+// from the minified output — the indexes below inline as numeric literals.
+const FOCUS_IN_HANDLER = 0;
+const FOCUS_OUT_HANDLER = 1;
+const SHADOW_TARGETS = 2;
+const LAST_FOCUSED_PROGRAMMATICALLY = 3;
+type KeyborgFocusEventData = [
+  (e: FocusEvent) => void,
+  (e: FocusEvent) => void,
+  Set<WeakRef<ShadowRoot>>,
+  WeakRef<HTMLElement>?,
+];
 
 /**
  * Extends the global window with keyborg focus event data
@@ -57,8 +63,7 @@ export interface KeyborgFocusInEventDetails {
   originalEvent?: FocusEvent;
 }
 
-export interface KeyborgFocusInEvent
-  extends CustomEvent<KeyborgFocusInEventDetails> {
+export interface KeyborgFocusInEvent extends CustomEvent<KeyborgFocusInEventDetails> {
   /**
    * @deprecated - used `event.detail`
    */
@@ -107,8 +112,8 @@ export function setupFocusEvent(win: Window): void {
 
   const shadowTargets: Set<WeakRef<ShadowRoot>> = new Set();
 
-  const focusOutHandler: EventListener = (e) => {
-    const target = (e as FocusEvent).target as HTMLElement;
+  const focusOutHandler = (e: FocusEvent) => {
+    const target = e.target as HTMLElement;
 
     if (!target) {
       return;
@@ -120,22 +125,21 @@ export function setupFocusEvent(win: Window): void {
       // Allows the event to bubble past an open shadow root
       composed: true,
       detail: {
-        originalEvent: e as FocusEvent,
+        originalEvent: e,
       },
     });
 
     target.dispatchEvent(event);
   };
 
-  const focusInHandler: EventListener = (e) => {
-    const focusEvent = e as FocusEvent;
-    const target = focusEvent.target as HTMLElement;
+  const focusInHandler = (e: FocusEvent) => {
+    const target = e.target as HTMLElement;
 
     if (!target) {
       return;
     }
 
-    let node: Node | null | undefined = focusEvent.composedPath()[0] as
+    let node: Node | null | undefined = e.composedPath()[0] as
       | Node
       | null
       | undefined;
@@ -158,16 +162,13 @@ export function setupFocusEvent(win: Window): void {
         shadowTargets.delete(shadowRootWeakRef);
 
         if (shadowRoot) {
-          off(shadowRoot, "focusin", focusInHandler);
-          off(shadowRoot, "focusout", focusOutHandler);
+          removeEventListener(shadowRoot, "focusin", focusInHandler);
+          removeEventListener(shadowRoot, "focusout", focusOutHandler);
         }
       }
     }
 
-    onFocusIn(
-      target,
-      (focusEvent.relatedTarget as HTMLElement | null) || undefined,
-    );
+    onFocusIn(target, (e.relatedTarget as HTMLElement | null) || undefined);
   };
 
   const onFocusIn = (
@@ -197,8 +198,8 @@ export function setupFocusEvent(win: Window): void {
         }
       }
 
-      on(shadowRoot, "focusin", focusInHandler);
-      on(shadowRoot, "focusout", focusOutHandler);
+      addEventListener(shadowRoot, "focusin", focusInHandler);
+      addEventListener(shadowRoot, "focusout", focusOutHandler);
 
       shadowTargets.add(new WeakRef(shadowRoot));
 
@@ -221,29 +222,31 @@ export function setupFocusEvent(win: Window): void {
     // Tabster (and other users) can still use the legacy details field - keeping for backwards compat
     event.details = details;
 
-    if (_canOverrideNativeFocus || data._lfp) {
-      details.isFocusedProgrammatically = target === data._lfp?.deref();
+    if (_canOverrideNativeFocus || data[LAST_FOCUSED_PROGRAMMATICALLY]) {
+      details.isFocusedProgrammatically =
+        target === data[LAST_FOCUSED_PROGRAMMATICALLY]?.deref();
 
-      data._lfp = undefined;
+      data[LAST_FOCUSED_PROGRAMMATICALLY] = undefined;
     }
 
     target.dispatchEvent(event);
   };
 
-  const data: KeyborgFocusEventData = (kwin.__keyborgData = {
-    _fi: focusInHandler,
-    _fo: focusOutHandler,
-    _st: shadowTargets,
-  });
+  const data: KeyborgFocusEventData = [
+    focusInHandler,
+    focusOutHandler,
+    shadowTargets,
+  ];
+  kwin.__keyborgData = data;
 
-  on(doc, "focusin", focusInHandler);
-  on(doc, "focusout", focusOutHandler);
+  addEventListener(doc, "focusin", focusInHandler);
+  addEventListener(doc, "focusout", focusOutHandler);
 
   function focus(this: HTMLElement) {
     const d = (kwin as WindowWithKeyborgFocusEvent).__keyborgData;
 
     if (d) {
-      d._lfp = new WeakRef(this);
+      d[LAST_FOCUSED_PROGRAMMATICALLY] = new WeakRef(this);
     }
 
     // eslint-disable-next-line prefer-rest-params
@@ -274,19 +277,20 @@ export function disposeFocusEvent(win: Window): void {
   const data = kwin.__keyborgData;
 
   if (data) {
-    off(kwin.document, "focusin", data._fi);
-    off(kwin.document, "focusout", data._fo);
+    const doc = kwin.document;
+    removeEventListener(doc, "focusin", data[FOCUS_IN_HANDLER]);
+    removeEventListener(doc, "focusout", data[FOCUS_OUT_HANDLER]);
 
-    for (const shadowRootWeakRef of data._st) {
+    for (const shadowRootWeakRef of data[SHADOW_TARGETS]) {
       const shadowRoot = shadowRootWeakRef.deref();
 
       if (shadowRoot) {
-        off(shadowRoot, "focusin", data._fi);
-        off(shadowRoot, "focusout", data._fo);
+        removeEventListener(shadowRoot, "focusin", data[FOCUS_IN_HANDLER]);
+        removeEventListener(shadowRoot, "focusout", data[FOCUS_OUT_HANDLER]);
       }
     }
 
-    data._st.clear();
+    data[SHADOW_TARGETS].clear();
 
     delete kwin.__keyborgData;
   }
@@ -305,5 +309,7 @@ export function getLastFocusedProgrammatically(
 ): HTMLElement | null | undefined {
   const data = (win as WindowWithKeyborgFocusEvent).__keyborgData;
 
-  return data ? data._lfp?.deref() || null : undefined;
+  return data
+    ? data[LAST_FOCUSED_PROGRAMMATICALLY]?.deref() || null
+    : undefined;
 }

--- a/src/Keyborg.mts
+++ b/src/Keyborg.mts
@@ -3,6 +3,7 @@
  * Licensed under the MIT License.
  */
 
+import { off, on } from "./dom.mts";
 import {
   disposeFocusEvent,
   KeyborgFocusInEvent,
@@ -217,12 +218,12 @@ function createKeyborgCore(
   };
 
   const targetDocument = targetWindow.document;
-  targetDocument.addEventListener(KEYBORG_FOCUSIN, onFocusIn, true);
-  targetDocument.addEventListener("mousedown", onMouseDown, true);
-  targetWindow.addEventListener("keydown", onKeyDown, true);
-  targetDocument.addEventListener("touchstart", onMouseOrTouch, true);
-  targetDocument.addEventListener("touchend", onMouseOrTouch, true);
-  targetDocument.addEventListener("touchcancel", onMouseOrTouch, true);
+  on(targetDocument, KEYBORG_FOCUSIN, onFocusIn as EventListener);
+  on(targetDocument, "mousedown", onMouseDown as EventListener);
+  on(targetWindow, "keydown", onKeyDown as EventListener);
+  on(targetDocument, "touchstart", onMouseOrTouch);
+  on(targetDocument, "touchend", onMouseOrTouch);
+  on(targetDocument, "touchcancel", onMouseOrTouch);
 
   setupFocusEvent(targetWindow);
 
@@ -240,12 +241,12 @@ function createKeyborgCore(
     }
     disposeFocusEvent(currentTargetWindow);
     const targetDocument = currentTargetWindow.document;
-    targetDocument.removeEventListener(KEYBORG_FOCUSIN, onFocusIn, true);
-    targetDocument.removeEventListener("mousedown", onMouseDown, true);
-    currentTargetWindow.removeEventListener("keydown", onKeyDown, true);
-    targetDocument.removeEventListener("touchstart", onMouseOrTouch, true);
-    targetDocument.removeEventListener("touchend", onMouseOrTouch, true);
-    targetDocument.removeEventListener("touchcancel", onMouseOrTouch, true);
+    off(targetDocument, KEYBORG_FOCUSIN, onFocusIn as EventListener);
+    off(targetDocument, "mousedown", onMouseDown as EventListener);
+    off(currentTargetWindow, "keydown", onKeyDown as EventListener);
+    off(targetDocument, "touchstart", onMouseOrTouch);
+    off(targetDocument, "touchend", onMouseOrTouch);
+    off(targetDocument, "touchcancel", onMouseOrTouch);
     currentTargetWindow = undefined;
   };
 

--- a/src/Keyborg.mts
+++ b/src/Keyborg.mts
@@ -3,7 +3,7 @@
  * Licensed under the MIT License.
  */
 
-import { off, on } from "./dom.mts";
+import { addEventListener, removeEventListener } from "./dom.mts";
 import {
   disposeFocusEvent,
   KeyborgFocusInEvent,
@@ -218,12 +218,12 @@ function createKeyborgCore(
   };
 
   const targetDocument = targetWindow.document;
-  on(targetDocument, KEYBORG_FOCUSIN, onFocusIn as EventListener);
-  on(targetDocument, "mousedown", onMouseDown as EventListener);
-  on(targetWindow, "keydown", onKeyDown as EventListener);
-  on(targetDocument, "touchstart", onMouseOrTouch);
-  on(targetDocument, "touchend", onMouseOrTouch);
-  on(targetDocument, "touchcancel", onMouseOrTouch);
+  addEventListener(targetDocument, KEYBORG_FOCUSIN, onFocusIn as EventListener);
+  addEventListener(targetDocument, "mousedown", onMouseDown as EventListener);
+  addEventListener(targetWindow, "keydown", onKeyDown as EventListener);
+  addEventListener(targetDocument, "touchstart", onMouseOrTouch);
+  addEventListener(targetDocument, "touchend", onMouseOrTouch);
+  addEventListener(targetDocument, "touchcancel", onMouseOrTouch);
 
   setupFocusEvent(targetWindow);
 
@@ -241,12 +241,24 @@ function createKeyborgCore(
     }
     disposeFocusEvent(currentTargetWindow);
     const targetDocument = currentTargetWindow.document;
-    off(targetDocument, KEYBORG_FOCUSIN, onFocusIn as EventListener);
-    off(targetDocument, "mousedown", onMouseDown as EventListener);
-    off(currentTargetWindow, "keydown", onKeyDown as EventListener);
-    off(targetDocument, "touchstart", onMouseOrTouch);
-    off(targetDocument, "touchend", onMouseOrTouch);
-    off(targetDocument, "touchcancel", onMouseOrTouch);
+    removeEventListener(
+      targetDocument,
+      KEYBORG_FOCUSIN,
+      onFocusIn as EventListener,
+    );
+    removeEventListener(
+      targetDocument,
+      "mousedown",
+      onMouseDown as EventListener,
+    );
+    removeEventListener(
+      currentTargetWindow,
+      "keydown",
+      onKeyDown as EventListener,
+    );
+    removeEventListener(targetDocument, "touchstart", onMouseOrTouch);
+    removeEventListener(targetDocument, "touchend", onMouseOrTouch);
+    removeEventListener(targetDocument, "touchcancel", onMouseOrTouch);
     currentTargetWindow = undefined;
   };
 

--- a/src/dom.mts
+++ b/src/dom.mts
@@ -1,0 +1,22 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+// All keyborg listeners use the capture phase; centralizing the calls lets the
+// minifier collapse repeated DOM method names.
+export const on = (
+  target: EventTarget,
+  type: string,
+  handler: EventListener,
+): void => {
+  target.addEventListener(type, handler, true);
+};
+
+export const off = (
+  target: EventTarget,
+  type: string,
+  handler: EventListener,
+): void => {
+  target.removeEventListener(type, handler, true);
+};

--- a/src/dom.mts
+++ b/src/dom.mts
@@ -4,8 +4,9 @@
  */
 
 // All keyborg listeners use the capture phase; centralizing the calls lets the
-// minifier collapse repeated DOM method names.
-export const on = (
+// minifier collapse the repeated DOM method names into a single short-named
+// import binding.
+export const addEventListener = (
   target: EventTarget,
   type: string,
   handler: EventListener,
@@ -13,7 +14,7 @@ export const on = (
   target.addEventListener(type, handler, true);
 };
 
-export const off = (
+export const removeEventListener = (
   target: EventTarget,
   type: string,
   handler: EventListener,


### PR DESCRIPTION
## Summary

Targeted follow-up to the bundle-size stack. A token-frequency analysis of the minified output identified `addEventListener`, `removeEventListener`, and `lastFocusedProgrammatically` as the costliest unmangled tokens. This PR attacks each.

- **New `src/dom.mts`** exporting `addEventListener(target, type, handler)` / `removeEventListener(target, type, handler)` — thin wrappers over the capture-phase DOM pattern that every keyborg listener uses. Call sites across `FocusEvent.mts` and `Keyborg.mts` route through them. The source reads like the DOM methods they wrap; the bundler mangles the import binding, so no bytes are lost to readability.
- **`__keyborgData` becomes a typed tuple** with module-local index constants (`FOCUS_IN_HANDLER`, `FOCUS_OUT_HANDLER`, `SHADOW_TARGETS`, `LAST_FOCUSED_PROGRAMMATICALLY`). The consts inline as numeric literals, so `data[FOCUS_IN_HANDLER]` minifies to `data[0]` — no property-name strings survive in the output.
- **Hoisted `doc` / `proto` locals** in `setupFocusEvent()` so repeated `kwin.document` / `kwin.HTMLElement.prototype` accesses mangle.

The outer `__keyborgData` and `__keyborgNativeFocus` names are both preserved so any external consumer probing the window (e.g. Tabster, devtools) is untouched.

## Notes for reviewers

- Source is slightly more ceremony than before (helper calls, indexed tuple access) but each change is narrow and has a measurable byte cost attached.
- The `event.details` (plural) legacy field in `KeyborgFocusInEvent` is still present; dropping it would be another ~30 B but is a breaking API change, so held off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)