### PR TITLE
fix: restore __keyborg cross-version interop (core + refs protocol)

### DIFF
--- a/src/Keyborg.mts
+++ b/src/Keyborg.mts
@@ -73,11 +73,14 @@ export interface Keyborg {
   setVal(isNavigatingWithKeyboard: boolean): void;
 }
 
-// Augments the public Keyborg with internal methods invoked by the core's
-// broadcast loop and by disposeKeyborg. Not exported.
+// Augments the public Keyborg with internal members that also form the
+// `__keyborg.refs` slot wire protocol. The shape — `_cb` callback array and
+// `dispose()` method — matches keyborg <= 2.6.0's `Keyborg` class so that
+// mixed-version environments can broadcast and tear down each other's
+// instances without TypeError. Changes here are breaking for that interop.
 interface KeyborgInternal extends Keyborg {
-  _notify(isNavigatingWithKeyboard: boolean): void;
-  _dispose(): void;
+  _cb: KeyborgCallback[];
+  dispose(): void;
 }
 
 function createKeyborgCore(
@@ -104,7 +107,7 @@ function createKeyborgCore(
     const refs = currentTargetWindow?.__keyborg?.refs;
     if (refs) {
       for (const id of Object.keys(refs)) {
-        (refs[id] as KeyborgInternal)._notify(isNavigating);
+        (refs[id] as KeyborgInternal)._cb.forEach((cb) => cb(isNavigating));
       }
     }
   };
@@ -283,7 +286,10 @@ export function createKeyborg(win: Window, props?: KeyborgProps): Keyborg {
   const id = "k" + ++_lastId;
   let localWin: WindowWithKeyborg | undefined = kwin;
   let core: KeyborgCoreHandle | undefined;
-  let callbacks: KeyborgCallback[] = [];
+  // `callbacks` is exposed as `instance._cb` to satisfy the slot wire
+  // protocol. We mutate the array in place (push/splice/length=0) so the
+  // reference stays stable for foreign-version broadcasts.
+  const callbacks: KeyborgCallback[] = [];
 
   const existing = kwin.__keyborg;
   if (existing) {
@@ -310,10 +316,8 @@ export function createKeyborg(win: Window, props?: KeyborgProps): Keyborg {
         core.isNavigatingWithKeyboard = val;
       }
     },
-    _notify(val) {
-      callbacks.forEach((cb) => cb(val));
-    },
-    _dispose() {
+    _cb: callbacks,
+    dispose() {
       const wkb = localWin?.__keyborg;
       if (wkb?.refs[id]) {
         delete wkb.refs[id];
@@ -325,7 +329,7 @@ export function createKeyborg(win: Window, props?: KeyborgProps): Keyborg {
       } else if (process.env.NODE_ENV !== "production") {
         console.error(`Keyborg instance ${id} is being disposed incorrectly.`);
       }
-      callbacks = [];
+      callbacks.length = 0;
       core = undefined;
       localWin = undefined;
     },
@@ -344,5 +348,5 @@ export function createKeyborg(win: Window, props?: KeyborgProps): Keyborg {
 }
 
 export function disposeKeyborg(instance: Keyborg): void {
-  (instance as KeyborgInternal)._dispose();
+  (instance as KeyborgInternal).dispose();
 }

--- a/src/Keyborg.mts
+++ b/src/Keyborg.mts
@@ -39,11 +39,16 @@ export type KeyborgCallback = (isNavigatingWithKeyboard: boolean) => void;
 
 /**
  * Internal handle for the per-window core state. Not part of the public API.
+ *
+ * Shape is part of the `__keyborg.core` slot contract: when multiple keyborg
+ * majors share the same window, the second loader reads `core` set by the
+ * first. Keep `isNavigatingWithKeyboard` as a writable property accessor and
+ * `dispose()` as a method so older majors can still read/write state without
+ * TypeError. Changes here are breaking for that interop.
  */
 interface KeyborgCoreHandle {
+  isNavigatingWithKeyboard: boolean;
   dispose(): void;
-  getNavigating(): boolean;
-  setNavigating(val: boolean): void;
 }
 
 /**
@@ -264,8 +269,12 @@ function createKeyborgCore(
 
   return {
     dispose,
-    getNavigating: () => isNavigating,
-    setNavigating,
+    get isNavigatingWithKeyboard() {
+      return isNavigating;
+    },
+    set isNavigatingWithKeyboard(val: boolean) {
+      setNavigating(val);
+    },
   };
 }
 
@@ -285,7 +294,7 @@ export function createKeyborg(win: Window, props?: KeyborgProps): Keyborg {
 
   const instance: KeyborgInternal = {
     isNavigatingWithKeyboard() {
-      return !!core?.getNavigating();
+      return !!core?.isNavigatingWithKeyboard;
     },
     subscribe(callback) {
       callbacks.push(callback);
@@ -297,7 +306,9 @@ export function createKeyborg(win: Window, props?: KeyborgProps): Keyborg {
       }
     },
     setVal(val) {
-      core?.setNavigating(val);
+      if (core) {
+        core.isNavigatingWithKeyboard = val;
+      }
     },
     _notify(val) {
       callbacks.forEach((cb) => cb(val));

--- a/tests/core-back-compat.spec.ts
+++ b/tests/core-back-compat.spec.ts
@@ -12,6 +12,11 @@ interface ForeignCore {
   dispose(): void;
 }
 
+interface ForeignInstance {
+  _cb: ((val: boolean) => void)[];
+  dispose?: () => void;
+}
+
 interface WindowWithKeyborgFactory extends Window {
   createKeyborg?: typeof createKeyborg;
   disposeKeyborg?: typeof disposeKeyborg;
@@ -141,4 +146,149 @@ test("__keyborg.core exposes property-accessor shape", async ({ page }) => {
   expect(result.initial).toBe(false);
   expect(result.afterWrite).toBe(true);
   expect(result.instanceRead).toBe(true);
+});
+
+// Forward direction: when keyborg owns the slot, its broadcast loop must
+// notify foreign-version instances sitting in `refs`. Foreign instances
+// expose callbacks as `_cb: ((val) => void)[]` (the 2.6.0 wire protocol).
+test("__keyborg.refs broadcast notifies foreign instances via _cb", async ({
+  page,
+}) => {
+  await page.goto("/iframe.html?id=core-back-compat--default");
+  await expect(page.getByTestId("fixture")).toBeVisible();
+
+  const result = await page.evaluate(() => {
+    const win = window as WindowWithKeyborgFactory;
+    const create = win.createKeyborg;
+    const dispose = win.disposeKeyborg;
+
+    if (!create || !dispose) {
+      throw new Error("keyborg factories not exposed by fixture");
+    }
+
+    const k = create(window);
+    const slot = win.__keyborg;
+
+    if (!slot) {
+      throw new Error("expected createKeyborg to populate window.__keyborg");
+    }
+
+    const seen: boolean[] = [];
+    const foreign: ForeignInstance = {
+      _cb: [(val) => seen.push(val)],
+    };
+    slot.refs["foreign"] = foreign;
+
+    slot.core.isNavigatingWithKeyboard = true;
+    slot.core.isNavigatingWithKeyboard = false;
+
+    delete slot.refs["foreign"];
+    dispose(k);
+
+    return { seen };
+  });
+
+  expect(result.seen).toEqual([true, false]);
+});
+
+// Reverse direction (the original crash repro): a foreign core owns the slot
+// and broadcasts state changes via the 2.6.0 protocol — iterating `refs` and
+// calling `instance._cb.forEach(cb => cb(val))`. The new instance must expose
+// a `_cb` array reflecting `subscribe`/`unsubscribe`.
+test("foreign core broadcasting via old protocol notifies new subscribers", async ({
+  page,
+}) => {
+  await page.goto("/iframe.html?id=core-back-compat--default");
+  await expect(page.getByTestId("fixture")).toBeVisible();
+
+  const result = await page.evaluate(() => {
+    const win = window as WindowWithKeyborgFactory;
+    const create = win.createKeyborg;
+    const dispose = win.disposeKeyborg;
+
+    if (!create || !dispose) {
+      throw new Error("keyborg factories not exposed by fixture");
+    }
+
+    let foreignNav = false;
+    let foreignDisposed = false;
+    const foreignCore: ForeignCore = {
+      get isNavigatingWithKeyboard() {
+        return foreignNav;
+      },
+      set isNavigatingWithKeyboard(val: boolean) {
+        if (foreignNav !== val) {
+          foreignNav = val;
+          const refs = win.__keyborg?.refs;
+          if (refs) {
+            for (const id of Object.keys(refs)) {
+              (refs[id] as ForeignInstance)._cb.forEach((cb) =>
+                cb(foreignNav),
+              );
+            }
+          }
+        }
+      },
+      dispose() {
+        foreignDisposed = true;
+      },
+    };
+
+    win.__keyborg = { core: foreignCore, refs: {} };
+
+    const k = create(window);
+    const seen: boolean[] = [];
+    const subscriber = (val: boolean) => seen.push(val);
+    k.subscribe(subscriber);
+
+    foreignCore.isNavigatingWithKeyboard = true;
+    foreignCore.isNavigatingWithKeyboard = false;
+
+    k.unsubscribe(subscriber);
+    foreignCore.isNavigatingWithKeyboard = true;
+
+    dispose(k);
+
+    return { seen, foreignDisposed };
+  });
+
+  // Only the two flips before unsubscribe should be observed.
+  expect(result.seen).toEqual([true, false]);
+  expect(result.foreignDisposed).toBe(true);
+});
+
+// 2.6.0's static `Keyborg.dispose(instance)` calls `instance.dispose()`. The
+// new instance must expose `dispose` as a callable property so cross-version
+// teardown does not throw.
+test("__keyborg.refs[id].dispose() is callable for cross-version teardown", async ({
+  page,
+}) => {
+  await page.goto("/iframe.html?id=core-back-compat--default");
+  await expect(page.getByTestId("fixture")).toBeVisible();
+
+  const result = await page.evaluate(() => {
+    const win = window as WindowWithKeyborgFactory;
+    const create = win.createKeyborg;
+
+    if (!create) {
+      throw new Error("keyborg factories not exposed by fixture");
+    }
+
+    create(window);
+    const slot = win.__keyborg;
+
+    if (!slot) {
+      throw new Error("expected createKeyborg to populate window.__keyborg");
+    }
+
+    const ids = Object.keys(slot.refs);
+    const inst = slot.refs[ids[0]] as ForeignInstance;
+    const hasDispose = typeof inst.dispose === "function";
+    inst.dispose?.();
+
+    return { hasDispose, slotCleared: !win.__keyborg };
+  });
+
+  expect(result.hasDispose).toBe(true);
+  expect(result.slotCleared).toBe(true);
 });

--- a/tests/core-back-compat.spec.ts
+++ b/tests/core-back-compat.spec.ts
@@ -222,9 +222,7 @@ test("foreign core broadcasting via old protocol notifies new subscribers", asyn
           const refs = win.__keyborg?.refs;
           if (refs) {
             for (const id of Object.keys(refs)) {
-              (refs[id] as ForeignInstance)._cb.forEach((cb) =>
-                cb(foreignNav),
-              );
+              (refs[id] as ForeignInstance)._cb.forEach((cb) => cb(foreignNav));
             }
           }
         }

--- a/tests/core-back-compat.spec.ts
+++ b/tests/core-back-compat.spec.ts
@@ -1,0 +1,144 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import { test, expect } from "@playwright/test";
+
+import type { createKeyborg, disposeKeyborg } from "../src/index.mts";
+
+interface ForeignCore {
+  isNavigatingWithKeyboard: boolean;
+  dispose(): void;
+}
+
+interface WindowWithKeyborgFactory extends Window {
+  createKeyborg?: typeof createKeyborg;
+  disposeKeyborg?: typeof disposeKeyborg;
+  __keyborg?: {
+    core: ForeignCore;
+    refs: Record<string, unknown>;
+  };
+}
+
+// Verifies that `createKeyborg` interoperates with a foreign `__keyborg.core`
+// using a property-accessor `isNavigatingWithKeyboard` and a `dispose()`
+// method. This is the slot-shape contract that lets multiple keyborg majors
+// coexist on the same window.
+test("createKeyborg interops with foreign __keyborg.core", async ({ page }) => {
+  await page.goto("/iframe.html?id=core-back-compat--default");
+  await expect(page.getByTestId("fixture")).toBeVisible();
+
+  const result = await page.evaluate(() => {
+    const win = window as WindowWithKeyborgFactory;
+    const create = win.createKeyborg;
+    const dispose = win.disposeKeyborg;
+
+    if (!create || !dispose) {
+      throw new Error("keyborg factories not exposed by fixture");
+    }
+
+    let foreignNav = false;
+    let setterCount = 0;
+    let disposed = false;
+
+    win.__keyborg = {
+      core: {
+        get isNavigatingWithKeyboard() {
+          return foreignNav;
+        },
+        set isNavigatingWithKeyboard(val: boolean) {
+          if (foreignNav !== val) {
+            foreignNav = val;
+            setterCount++;
+          }
+        },
+        dispose() {
+          disposed = true;
+        },
+      },
+      refs: {},
+    };
+
+    const k = create(window);
+    const initialRead = k.isNavigatingWithKeyboard();
+
+    k.setVal(true);
+    const afterSetTrueForeign = foreignNav;
+    const afterSetTrueRead = k.isNavigatingWithKeyboard();
+
+    k.setVal(false);
+    const afterSetFalseForeign = foreignNav;
+
+    dispose(k);
+
+    return {
+      initialRead,
+      afterSetTrueForeign,
+      afterSetTrueRead,
+      afterSetFalseForeign,
+      setterCount,
+      disposed,
+      slotCleared: !win.__keyborg,
+    };
+  });
+
+  expect(result.initialRead).toBe(false);
+  expect(result.afterSetTrueForeign).toBe(true);
+  expect(result.afterSetTrueRead).toBe(true);
+  expect(result.afterSetFalseForeign).toBe(false);
+  expect(result.setterCount).toBe(2);
+  expect(result.disposed).toBe(true);
+  expect(result.slotCleared).toBe(true);
+});
+
+// Verifies the inverse: when keyborg owns the slot, `__keyborg.core` exposes
+// a writable `isNavigatingWithKeyboard` property accessor — what an older
+// keyborg sharing the window would read and write.
+test("__keyborg.core exposes property-accessor shape", async ({ page }) => {
+  await page.goto("/iframe.html?id=core-back-compat--default");
+  await expect(page.getByTestId("fixture")).toBeVisible();
+
+  const result = await page.evaluate(() => {
+    const win = window as WindowWithKeyborgFactory;
+    const create = win.createKeyborg;
+    const dispose = win.disposeKeyborg;
+
+    if (!create || !dispose) {
+      throw new Error("keyborg factories not exposed by fixture");
+    }
+
+    const k = create(window);
+    const slot = win.__keyborg;
+
+    if (!slot) {
+      throw new Error("expected createKeyborg to populate window.__keyborg");
+    }
+
+    const descriptor = Object.getOwnPropertyDescriptor(
+      slot.core,
+      "isNavigatingWithKeyboard",
+    );
+
+    const initial = slot.core.isNavigatingWithKeyboard;
+    slot.core.isNavigatingWithKeyboard = true;
+    const afterWrite = slot.core.isNavigatingWithKeyboard;
+    const instanceRead = k.isNavigatingWithKeyboard();
+
+    dispose(k);
+
+    return {
+      hasGetter: typeof descriptor?.get === "function",
+      hasSetter: typeof descriptor?.set === "function",
+      initial,
+      afterWrite,
+      instanceRead,
+    };
+  });
+
+  expect(result.hasGetter).toBe(true);
+  expect(result.hasSetter).toBe(true);
+  expect(result.initial).toBe(false);
+  expect(result.afterWrite).toBe(true);
+  expect(result.instanceRead).toBe(true);
+});

--- a/tests/core-back-compat.stories.tsx
+++ b/tests/core-back-compat.stories.tsx
@@ -1,0 +1,24 @@
+/*!
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License.
+ */
+
+import * as React from "react";
+
+import { createKeyborg, disposeKeyborg } from "../src/index.mts";
+
+interface WindowWithKeyborgFactory extends Window {
+  createKeyborg?: typeof createKeyborg;
+  disposeKeyborg?: typeof disposeKeyborg;
+}
+
+const meta = { title: "Core Back Compat" };
+export default meta;
+
+// Empty fixture: exposes the factories on `window` so the spec can install a
+// foreign-shaped `__keyborg.core` before keyborg is initialized.
+export const Default = () => {
+  (window as WindowWithKeyborgFactory).createKeyborg = createKeyborg;
+  (window as WindowWithKeyborgFactory).disposeKeyborg = disposeKeyborg;
+  return <div data-testid="fixture">core back compat fixture</div>;
+};


### PR DESCRIPTION
## Summary

PR #144 (closure-based factory refactor) silently changed the wire protocol of `window.__keyborg`. Two boundaries were affected:

1. **`__keyborg.core`**: old keyborg exposed an `isNavigatingWithKeyboard` getter/setter pair; new keyborg replaced this with `getNavigating()` / `setNavigating()` methods.
2. **`__keyborg.refs[id]`**: old keyborg's static broadcast called `instance._cb.forEach(cb => cb(val))`, and static dispose called `instance.dispose()`; new keyborg replaced these with `_notify(val)` and `_dispose()`.

`window.__keyborg` is a **shared slot**: when multiple keyborg majors load on the same page, the second loader reads the `core` set by the first and adds its own instances to the shared `refs`. Both protocol changes break mixed-version pages — for example:

```
@fluentui/react-tabster@9.26.14
├── keyborg@2.14.0   ← new closure shape
└── tabster@8.7.0
    └── keyborg@2.6.0 ← old class shape (loaded first via tabster)
```

When tabster's 2.6.0 owns the slot, 2.14.0 reads `core.getNavigating()` → `TypeError: core?.getNavigating is not a function`. After that path is fixed, the next keydown crashes the old broadcast: `KeyborgCore._onKeyDown` → `set isNavigatingWithKeyboard` → `KeyborgCore.update` → `Keyborg.update(refs[id], val)` → `instance._cb.forEach` → undefined. Same family produces the `Keyborg instance kN is being disposed incorrectly` warning.

## Fix

Treat the 2.6.0 wire protocol as the frozen cross-version contract — until tabster ships a release that depends on keyborg ≥ 2.14.x, the slot shape is constrained to what 2.6.0 published. Closure internals and external API from PR #144 are kept as-is; only the slot-visible surface is rolled back.

**Core (`__keyborg.core`)**
- `KeyborgCoreHandle` now exposes a writable `isNavigatingWithKeyboard` property accessor + `dispose()`.
- `setVal` writes via `core.isNavigatingWithKeyboard = val` — works on either shape sharing the slot.

**Refs (`__keyborg.refs[id]`)**
- Each instance exposes `_cb: KeyborgCallback[]` (the same callbacks array used by `subscribe`/`unsubscribe`, mutated in place to keep the reference stable).
- Each instance exposes `dispose()` (renamed from `_dispose()`); `disposeKeyborg(instance)` now calls `instance.dispose()`.
- New broadcast loop iterates `(refs[id] as KeyborgInternal)._cb.forEach(cb => cb(val))` — same wire protocol both versions speak.

This means cross-major slot share works in both directions:
- Reading state and broadcasting through old or new core both succeed.
- The dispose dispatch path (`instance.dispose()`) works regardless of which version's static dispose initiated it.

The `KeyborgInternal` and `KeyborgCoreHandle` JSDocs document this slot-shape contract explicitly so future refactors don't silently break it again.

## Known leftover gaps (out of scope)

- **Duplicate keydown handlers**: each version installs its own capture-phase listener on `window`. Each independently flips its own internal `isNavigating` and broadcasts. Subscribers may be notified by both — idempotent for typical consumers (React `setState` dedupes). No crash.
- **Cross-version state divergence**: each version's internal `isNavigating` is a separate variable. Each version's own keydown/focus/mouse handlers keep its own state in sync, and after this fix subscribers from both sides are reached by both broadcasts.
- **Slot versioning** (`__keyborg_v2`) was considered and rejected: it would sacrifice the shared-state semantics consumers depend on during the tabster migration window.

## Tests

`tests/core-back-compat.{spec,stories}.tsx` (Playwright) — five cases:

1. **Foreign core present, own instance**: pre-installs a fake old-shape core; verifies our instance reads/writes through the foreign accessors and that disposing the only ref runs the foreign `dispose()` and clears the slot.
2. **Own slot, accessor surface**: verifies `core.isNavigatingWithKeyboard` is a getter+setter accessor pair (not a data property), and that writing to it flips the instance's reported state.
3. **Forward broadcast**: pushes a foreign-shape instance into our `refs`, flips state via the core setter, verifies the foreign `_cb` callback fires.
4. **Reverse broadcast (original crash repro)**: foreign core owns the slot and broadcasts state changes via the 2.6.0 protocol — iterating `refs` and calling `instance._cb.forEach`. Verifies our subscribers are reached and that `unsubscribe` removes them. Also asserts the foreign core's `dispose()` is invoked when the last ref is torn down.
5. **Cross-version dispose dispatch**: verifies `refs[id].dispose` is a callable that, when invoked directly (mimicking 2.6.0's static dispose path), tears down cleanly.

Full suite: 14/14 passing.

## Test plan

- [x] `npx tsc --noEmit -p .`
- [x] `npx eslint src/ tests/`
- [x] `npx prettier --check`
- [x] `npx playwright test` (14/14)
- [ ] Reviewer sanity check on the slot-shape JSDocs

🤖 Generated with [Claude Code](https://claude.com/claude-code)