### PR TITLE
chore: sync package.json version with npm latest (2.14.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keyborg",
-  "version": "2.14.0",
+  "version": "2.14.1",
   "description": "Keyboard Navigation Detection for Web",
   "author": "Marat Abdullin <marata@microsoft.com>",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Bumps `package.json` version from `2.14.0` to `2.14.1` to match the current `latest` dist-tag on npm.
- Follows the same pattern as #148 (`2.14.0-canary.0` → `2.14.0`).

## Test plan
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)