### PR TITLE
perf: drop unused code paths (event.details alias, KeyborgProps, IE9 probe)

### DIFF
--- a/src/FocusEvent.mts
+++ b/src/FocusEvent.mts
@@ -64,12 +64,7 @@ export interface KeyborgFocusInEventDetails {
   originalEvent?: FocusEvent;
 }
 
-export interface KeyborgFocusInEvent extends CustomEvent<KeyborgFocusInEventDetails> {
-  /**
-   * @deprecated - used `event.detail`
-   */
-  details?: KeyborgFocusInEventDetails;
-}
+export type KeyborgFocusInEvent = CustomEvent<KeyborgFocusInEventDetails>;
 
 export interface KeyborgFocusOutEventDetails {
   originalEvent: FocusEvent;
@@ -254,9 +249,6 @@ export function setupFocusEvent(win: Window): void {
       composed: true,
       detail: details,
     });
-
-    // Tabster (and other users) can still use the legacy details field - keeping for backwards compat
-    event.details = details;
 
     if (_canOverrideNativeFocus || data[LAST_FOCUSED_PROGRAMMATICALLY]) {
       details.isFocusedProgrammatically =

--- a/src/FocusEvent.mts
+++ b/src/FocusEvent.mts
@@ -37,27 +37,6 @@ interface WindowWithKeyborgFocusEvent extends Window {
   __keyborgData?: KeyborgFocusEventData;
 }
 
-function canOverrideNativeFocus(win: Window): boolean {
-  const HTMLElement = (win as WindowWithKeyborgFocusEvent).HTMLElement;
-  const origFocus = HTMLElement.prototype.focus;
-
-  let isCustomFocusCalled = false;
-
-  HTMLElement.prototype.focus = function focus(): void {
-    isCustomFocusCalled = true;
-  };
-
-  const btn = win.document.createElement("button");
-
-  btn.focus();
-
-  HTMLElement.prototype.focus = origFocus;
-
-  return isCustomFocusCalled;
-}
-
-let _canOverrideNativeFocus = false;
-
 export interface KeyborgFocusInEventDetails {
   relatedTarget?: HTMLElement;
   isFocusedProgrammatically?: boolean;
@@ -92,11 +71,6 @@ export function setupFocusEvent(win: Window): void {
   const kwin = win as WindowWithKeyborgFocusEvent;
   const doc = kwin.document;
   const proto = kwin.HTMLElement.prototype;
-
-  if (!_canOverrideNativeFocus) {
-    _canOverrideNativeFocus = canOverrideNativeFocus(kwin);
-  }
-
   const origFocus = proto.focus;
 
   if ((origFocus as KeyborgFocus).__keyborgNativeFocus) {
@@ -250,12 +224,10 @@ export function setupFocusEvent(win: Window): void {
       detail: details,
     });
 
-    if (_canOverrideNativeFocus || data[LAST_FOCUSED_PROGRAMMATICALLY]) {
-      details.isFocusedProgrammatically =
-        target === data[LAST_FOCUSED_PROGRAMMATICALLY]?.deref();
+    details.isFocusedProgrammatically =
+      target === data[LAST_FOCUSED_PROGRAMMATICALLY]?.deref();
 
-      data[LAST_FOCUSED_PROGRAMMATICALLY] = undefined;
-    }
+    data[LAST_FOCUSED_PROGRAMMATICALLY] = undefined;
 
     target.dispatchEvent(event);
   };

--- a/src/Keyborg.mts
+++ b/src/Keyborg.mts
@@ -18,22 +18,7 @@ interface WindowWithKeyborg extends Window {
   };
 }
 
-// When a key from dismissKeys is pressed and the focus is not moved during
-// _dismissTimeout ms, keyboard navigation mode is dismissed.
-const _dismissTimeout = 500;
-
 let _lastId = 0;
-
-export interface KeyborgProps {
-  // Keys to be used to trigger keyboard navigation mode. By default, any key
-  // will trigger it. Could be limited to, for example, just Tab (or Tab and
-  // arrow keys).
-  triggerKeys?: number[];
-  // Keys to be used to dismiss keyboard navigation mode using keyboard (in
-  // addition to mouse clicks which dismiss it). For example, Esc could be used
-  // to dismiss.
-  dismissKeys?: number[];
-}
 
 export type KeyborgCallback = (isNavigatingWithKeyboard: boolean) => void;
 
@@ -83,25 +68,10 @@ interface KeyborgInternal extends Keyborg {
   dispose(): void;
 }
 
-function createKeyborgCore(
-  targetWindow: WindowWithKeyborg,
-  props?: KeyborgProps,
-): KeyborgCoreHandle {
+function createKeyborgCore(targetWindow: WindowWithKeyborg): KeyborgCoreHandle {
   let currentTargetWindow: WindowWithKeyborg | undefined = targetWindow;
   let isNavigating = false;
   let isMouseOrTouchUsedTimer: number | undefined;
-  let dismissTimer: number | undefined;
-  let triggerKeys: Set<number> | undefined;
-  let dismissKeys: Set<number> | undefined;
-
-  if (props) {
-    if (props.triggerKeys?.length) {
-      triggerKeys = new Set(props.triggerKeys);
-    }
-    if (props.dismissKeys?.length) {
-      dismissKeys = new Set(props.dismissKeys);
-    }
-  }
 
   const broadcast = (): void => {
     const refs = currentTargetWindow?.__keyborg?.refs;
@@ -128,42 +98,12 @@ function createKeyborgCore(
     }
     const active = currentTargetWindow?.document
       .activeElement as HTMLElement | null;
-    const isTriggerKey = !triggerKeys || triggerKeys.has(e.keyCode);
     const isEditable =
       active &&
       (active.tagName === "INPUT" ||
         active.tagName === "TEXTAREA" ||
         active.isContentEditable);
-    return isTriggerKey && !isEditable;
-  };
-
-  const shouldDismiss = (e: KeyboardEvent): boolean => {
-    return !!dismissKeys?.has(e.keyCode);
-  };
-
-  const scheduleDismiss = (): void => {
-    const targetWindow = currentTargetWindow;
-    if (!targetWindow) {
-      return;
-    }
-    if (dismissTimer) {
-      targetWindow.clearTimeout(dismissTimer);
-      dismissTimer = undefined;
-    }
-    const previousActiveElement = targetWindow.document.activeElement;
-    dismissTimer = targetWindow.setTimeout(() => {
-      dismissTimer = undefined;
-      const currentActiveElement = targetWindow.document.activeElement;
-      if (
-        previousActiveElement &&
-        currentActiveElement &&
-        previousActiveElement === currentActiveElement
-      ) {
-        // Esc was pressed, currently focused element hasn't changed.
-        // Just dismiss the keyboard navigation mode.
-        setNavigating(false);
-      }
-    }, _dismissTimeout);
+    return !isEditable;
   };
 
   const onFocusIn = (e: KeyborgFocusInEvent): void => {
@@ -216,11 +156,7 @@ function createKeyborgCore(
   };
 
   const onKeyDown = (e: KeyboardEvent): void => {
-    if (isNavigating) {
-      if (shouldDismiss(e)) {
-        scheduleDismiss();
-      }
-    } else if (shouldTrigger(e)) {
+    if (!isNavigating && shouldTrigger(e)) {
       setNavigating(true);
     }
   };
@@ -242,10 +178,6 @@ function createKeyborgCore(
     if (isMouseOrTouchUsedTimer) {
       currentTargetWindow.clearTimeout(isMouseOrTouchUsedTimer);
       isMouseOrTouchUsedTimer = undefined;
-    }
-    if (dismissTimer) {
-      currentTargetWindow.clearTimeout(dismissTimer);
-      dismissTimer = undefined;
     }
     disposeFocusEvent(currentTargetWindow);
     const targetDocument = currentTargetWindow.document;
@@ -281,7 +213,7 @@ function createKeyborgCore(
   };
 }
 
-export function createKeyborg(win: Window, props?: KeyborgProps): Keyborg {
+export function createKeyborg(win: Window): Keyborg {
   const kwin = win as WindowWithKeyborg;
   const id = "k" + ++_lastId;
   let localWin: WindowWithKeyborg | undefined = kwin;
@@ -295,7 +227,7 @@ export function createKeyborg(win: Window, props?: KeyborgProps): Keyborg {
   if (existing) {
     core = existing.core;
   } else {
-    core = createKeyborgCore(kwin, props);
+    core = createKeyborgCore(kwin);
   }
 
   const instance: KeyborgInternal = {


### PR DESCRIPTION
## Summary

Three independent trims that remove code paths none of keyborg's known consumers exercise. Upstreams the changes microsoft/tabster#539 currently applies via `patch-package` against `keyborg@2.14.0`'s installed bundle.

The commit is split into three commits for clean review and bisection:

1. **`event.details` alias on `KeyborgFocusInEvent`** — the `@deprecated` alias of `event.detail`. Tabster reads `e.detail` exclusively (verified across `src/State/FocusedElement.ts` and the rest of the codebase). Drops the field on the interface plus the per-dispatch `event.details = details` assignment in `setupFocusEvent`.

2. **`KeyborgProps` (`triggerKeys` / `dismissKeys`) + dismiss timer machinery** — `KeyborgProps` was never re-exported from `src/index.mts` and no known consumer passes props to `createKeyborg`. Removes the interface, the `triggerKeys`/`dismissKeys` Sets, `shouldDismiss`/`scheduleDismiss`/`dismissTimer`/`_dismissTimeout`, and collapses `onKeyDown` to a single trigger guard.

3. **`canOverrideNativeFocus` runtime probe + `_canOverrideNativeFocus` flag** — the probe detected pre-IE9 environments where reassigning `HTMLElement.prototype.focus` was ignored. Every browser keyborg currently supports honours the override, so the gated `details.isFocusedProgrammatically` write becomes unconditional. Semantically identical when the override works, which is the only case we still ship for.

## Public API impact

- `KeyborgFocusInEvent` interface no longer carries `details?: KeyborgFocusInEventDetails`. The field has been marked `@deprecated` for several releases; consumers should use `event.detail`.
- `createKeyborg(win, props?)` → `createKeyborg(win)`. `KeyborgProps` type is removed. Not previously re-exported, so the only breakage is callers passing the second argument (the type narrowing already silently ignored unknown shapes — passing `undefined` continues to work since the parameter is gone entirely).
- No runtime contract changes on `__keyborg.core` or `__keyborg.refs`.

Worth treating as a minor or major bump depending on how the maintainers want to handle the dropped `details` field.

## Bundle deltas (monosize)

```
                                    Before        After          Δ
All exports                         3.974 kB min  3.363 kB min   −611 B (−15.4%)
                                    1.627 kB gz   1.409 kB gz    −218 B (−13.4%)

createKeyborg + disposeKeyborg      3.806 kB min  3.195 kB min   −611 B (−16.1%)
                                    1.586 kB gz   1.368 kB gz    −218 B (−13.7%)

KEYBORG_FOCUSIN constant            64 B / 80 B   64 B / 80 B    unchanged
```

Matches microsoft/tabster#539's measurement of `−590 B` on keyborg's slice of the Tabster bundle within ~20 B of slack.

## Tests

Existing Playwright suite (14 tests covering focus behavior, focus-in events, shadow DOM nesting, and cross-version interop) passes unchanged.

## Test plan

- [x] `yarn build` (CJS + ESM, types)
- [x] `yarn lint`
- [x] `yarn format`
- [x] `yarn test` (14/14)
- [x] `yarn bundle-size`
- [ ] Reviewer: decide on semver level (minor with deprecation removal call-out vs. major)

🤖 Generated with [Claude Code](https://claude.com/claude-code)