### PR TITLE
chore: drop canOverrideNativeFocus runtime probe

### DIFF
--- a/src/FocusEvent.mts
+++ b/src/FocusEvent.mts
@@ -37,27 +37,6 @@ interface WindowWithKeyborgFocusEvent extends Window {
   __keyborgData?: KeyborgFocusEventData;
 }
 
-function canOverrideNativeFocus(win: Window): boolean {
-  const HTMLElement = (win as WindowWithKeyborgFocusEvent).HTMLElement;
-  const origFocus = HTMLElement.prototype.focus;
-
-  let isCustomFocusCalled = false;
-
-  HTMLElement.prototype.focus = function focus(): void {
-    isCustomFocusCalled = true;
-  };
-
-  const btn = win.document.createElement("button");
-
-  btn.focus();
-
-  HTMLElement.prototype.focus = origFocus;
-
-  return isCustomFocusCalled;
-}
-
-let _canOverrideNativeFocus = false;
-
 export interface KeyborgFocusInEventDetails {
   relatedTarget?: HTMLElement;
   isFocusedProgrammatically?: boolean;
@@ -97,11 +76,6 @@ export function setupFocusEvent(win: Window): void {
   const kwin = win as WindowWithKeyborgFocusEvent;
   const doc = kwin.document;
   const proto = kwin.HTMLElement.prototype;
-
-  if (!_canOverrideNativeFocus) {
-    _canOverrideNativeFocus = canOverrideNativeFocus(kwin);
-  }
-
   const origFocus = proto.focus;
 
   if ((origFocus as KeyborgFocus).__keyborgNativeFocus) {
@@ -258,12 +232,10 @@ export function setupFocusEvent(win: Window): void {
     // Tabster (and other users) can still use the legacy details field - keeping for backwards compat
     event.details = details;
 
-    if (_canOverrideNativeFocus || data[LAST_FOCUSED_PROGRAMMATICALLY]) {
-      details.isFocusedProgrammatically =
-        target === data[LAST_FOCUSED_PROGRAMMATICALLY]?.deref();
+    details.isFocusedProgrammatically =
+      target === data[LAST_FOCUSED_PROGRAMMATICALLY]?.deref();
 
-      data[LAST_FOCUSED_PROGRAMMATICALLY] = undefined;
-    }
+    data[LAST_FOCUSED_PROGRAMMATICALLY] = undefined;
 
     target.dispatchEvent(event);
   };


### PR DESCRIPTION
## Summary

`canOverrideNativeFocus` was a feature-detection helper that temporarily reassigned `HTMLElement.prototype.focus` to a no-op, called `.focus()` on a synthetic button, and checked whether the override fired. The result was cached in the module-level `_canOverrideNativeFocus` flag and gated the `details.isFocusedProgrammatically` write inside `setupFocusEvent`.

The probe guarded against pre-IE9 environments where prototype-level focus overrides were ignored. Every browser keyborg currently supports honours the override, so the flag is effectively always true after the first call.

Drops:
- the `canOverrideNativeFocus` function (~17 lines of synthetic-button-focus dance),
- the module-level `_canOverrideNativeFocus` flag,
- the lazy initialization branch inside `setupFocusEvent`.

The gated `isFocusedProgrammatically` write becomes unconditional:

```ts
// before
if (_canOverrideNativeFocus || data[LAST_FOCUSED_PROGRAMMATICALLY]) {
  details.isFocusedProgrammatically =
    target === data[LAST_FOCUSED_PROGRAMMATICALLY]?.deref();
  data[LAST_FOCUSED_PROGRAMMATICALLY] = undefined;
}

// after
details.isFocusedProgrammatically =
  target === data[LAST_FOCUSED_PROGRAMMATICALLY]?.deref();
data[LAST_FOCUSED_PROGRAMMATICALLY] = undefined;
```

Semantically identical when the override works, which is the only case still in scope.

## Public API impact

None. `canOverrideNativeFocus` was module-private; `_canOverrideNativeFocus` was a module-private variable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)