### PR TITLE
fix: support getter-only focus descriptors

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -3,34 +3,8 @@
  * Licensed under the MIT License.
  */
 
-import * as React from "react";
-import type { Decorator, Preview } from "@storybook/react-vite";
+import type { Preview } from "@storybook/react-vite";
 
-// Capture the original focus method before Storybook's test addon may patch it.
-const originalFocus = HTMLElement.prototype.focus;
-
-// Storybook 10.5+ adds a `enhanceContext` loader that installs an accessor
-// getter on HTMLElement.prototype.focus (for its component-testing / user-event
-// integration). That getter calls `this.ownerDocument`, which throws
-// "Illegal invocation" when `this` is HTMLElement.prototype itself – exactly
-// the access pattern used by keyborg's setupFocusEvent to retrieve the native
-// focus method.
-//
-// Global decorators run after all loaders have resolved, so this is a safe
-// place to restore focus to a plain value property before each story renders.
-const keyborgCompatDecorator: Decorator = (Story) => {
-  if (Object.getOwnPropertyDescriptor(HTMLElement.prototype, "focus")?.get) {
-    Object.defineProperty(HTMLElement.prototype, "focus", {
-      configurable: true,
-      writable: true,
-      value: originalFocus,
-    });
-  }
-  return <Story />;
-};
-
-const preview: Preview = {
-  decorators: [keyborgCompatDecorator],
-};
+const preview: Preview = {};
 
 export default preview;

--- a/src/FocusEvent.mts
+++ b/src/FocusEvent.mts
@@ -10,9 +10,13 @@ export const KEYBORG_FOCUSOUT = "keyborg:focusout";
 
 interface KeyborgFocus {
   /**
-   * This is the native `focus` function that is retained so that it can be restored when keyborg is disposed
+   * Calls the original `focus` implementation without marking focus as programmatic.
    */
   __keyborgNativeFocus?: (options?: FocusOptions | undefined) => void;
+  /**
+   * The original descriptor, retained so it can be restored when keyborg is disposed.
+   */
+  __keyborgFocusDescriptor?: PropertyDescriptor;
 }
 
 // Internal data stored on `window.__keyborgData` as a tuple. Nothing outside
@@ -71,14 +75,23 @@ export function setupFocusEvent(win: Window): void {
   const kwin = win as WindowWithKeyborgFocusEvent;
   const doc = kwin.document;
   const proto = kwin.HTMLElement.prototype;
-  const origFocus = proto.focus;
+  const origFocusDescriptor = Object.getOwnPropertyDescriptor(proto, "focus");
+  const currentFocus = origFocusDescriptor?.value as KeyborgFocus | undefined;
 
-  if ((origFocus as KeyborgFocus).__keyborgNativeFocus) {
+  if (currentFocus?.__keyborgNativeFocus) {
     // Already set up.
     return;
   }
 
-  proto.focus = focus;
+  (focus as KeyborgFocus).__keyborgNativeFocus = callNativeFocus;
+  (focus as KeyborgFocus).__keyborgFocusDescriptor = origFocusDescriptor;
+
+  Object.defineProperty(proto, "focus", {
+    configurable: origFocusDescriptor?.configurable ?? true,
+    enumerable: origFocusDescriptor?.enumerable ?? false,
+    writable: true,
+    value: focus,
+  });
 
   const shadowTargets: Set<WeakRef<ShadowRoot>> = new Set();
 
@@ -248,7 +261,20 @@ export function setupFocusEvent(win: Window): void {
     }
 
     // eslint-disable-next-line prefer-rest-params
-    return origFocus.apply(this, arguments);
+    return callNativeFocus.apply(this, arguments);
+  }
+
+  function callNativeFocus(this: HTMLElement) {
+    const originalFocus = origFocusDescriptor?.get
+      ? origFocusDescriptor.get.call(this)
+      : origFocusDescriptor?.value;
+
+    if (typeof originalFocus !== "function") {
+      throw new TypeError("HTMLElement.prototype.focus is not callable");
+    }
+
+    // eslint-disable-next-line prefer-rest-params
+    return originalFocus.apply(this, arguments);
   }
 
   let activeElement = doc.activeElement as Element | null;
@@ -260,8 +286,6 @@ export function setupFocusEvent(win: Window): void {
     onFocusIn(activeElement);
     activeElement = activeElement.shadowRoot.activeElement;
   }
-
-  (focus as KeyborgFocus).__keyborgNativeFocus = origFocus;
 }
 
 /**
@@ -271,7 +295,9 @@ export function setupFocusEvent(win: Window): void {
 export function disposeFocusEvent(win: Window): void {
   const kwin = win as WindowWithKeyborgFocusEvent;
   const proto = kwin.HTMLElement.prototype;
-  const origFocus = (proto.focus as KeyborgFocus).__keyborgNativeFocus;
+  const focusDescriptor = Object.getOwnPropertyDescriptor(proto, "focus");
+  const focus = focusDescriptor?.value as KeyborgFocus | undefined;
+  const origFocusDescriptor = focus?.__keyborgFocusDescriptor;
   const data = kwin.__keyborgData;
 
   if (data) {
@@ -293,8 +319,12 @@ export function disposeFocusEvent(win: Window): void {
     delete kwin.__keyborgData;
   }
 
-  if (origFocus) {
-    proto.focus = origFocus;
+  if (focus?.__keyborgNativeFocus) {
+    if (origFocusDescriptor) {
+      Object.defineProperty(proto, "focus", origFocusDescriptor);
+    } else {
+      delete proto.focus;
+    }
   }
 }
 

--- a/tests/core-back-compat.spec.ts
+++ b/tests/core-back-compat.spec.ts
@@ -5,7 +5,11 @@
 
 import { test, expect } from "@playwright/test";
 
-import type { createKeyborg, disposeKeyborg } from "../src/index.mts";
+import type {
+  createKeyborg,
+  disposeKeyborg,
+  nativeFocus,
+} from "../src/index.mts";
 
 interface ForeignCore {
   isNavigatingWithKeyboard: boolean;
@@ -20,11 +24,99 @@ interface ForeignInstance {
 interface WindowWithKeyborgFactory extends Window {
   createKeyborg?: typeof createKeyborg;
   disposeKeyborg?: typeof disposeKeyborg;
+  nativeFocus?: typeof nativeFocus;
   __keyborg?: {
     core: ForeignCore;
     refs: Record<string, unknown>;
   };
 }
+
+test("supports a configurable getter-only focus descriptor", async ({
+  page,
+}) => {
+  await page.goto("/iframe.html?id=core-back-compat--default");
+  await expect(page.getByTestId("fixture")).toBeVisible();
+
+  const result = await page.evaluate(() => {
+    const win = window as WindowWithKeyborgFactory;
+    const create = win.createKeyborg;
+    const dispose = win.disposeKeyborg;
+    const callNativeFocus = win.nativeFocus;
+
+    if (!create || !dispose || !callNativeFocus) {
+      throw new Error("keyborg factories not exposed by fixture");
+    }
+
+    const proto = HTMLElement.prototype;
+    const initialDescriptor = Object.getOwnPropertyDescriptor(proto, "focus");
+
+    if (!initialDescriptor) {
+      throw new Error("expected HTMLElement.prototype.focus descriptor");
+    }
+
+    const originalFocus = initialDescriptor.get
+      ? (element: HTMLElement) => initialDescriptor.get?.call(element)
+      : () => initialDescriptor.value;
+    let getterCalls = 0;
+    const getter = function (this: HTMLElement) {
+      if (this === proto) {
+        throw new Error("focus getter invoked on HTMLElement.prototype");
+      }
+
+      getterCalls++;
+      return originalFocus(this);
+    };
+
+    Object.defineProperty(proto, "focus", {
+      configurable: true,
+      enumerable: initialDescriptor.enumerable,
+      get: getter,
+    });
+
+    try {
+      const keyborg = create(window);
+      const button = document.createElement("button");
+      document.body.append(button);
+      const programmaticFocus: Array<boolean | undefined> = [];
+      button.addEventListener("keyborg:focusin", (event) => {
+        programmaticFocus.push(
+          (event as CustomEvent<{ isFocusedProgrammatically?: boolean }>).detail
+            .isFocusedProgrammatically,
+        );
+      });
+
+      button.focus();
+      button.blur();
+      callNativeFocus(button);
+
+      dispose(keyborg);
+
+      const restoredDescriptor = Object.getOwnPropertyDescriptor(
+        proto,
+        "focus",
+      );
+
+      return {
+        getterCalls,
+        programmaticFocus,
+        restoredGetter: restoredDescriptor?.get === getter,
+        restoredSetter: restoredDescriptor?.set,
+        restoredConfigurable: restoredDescriptor?.configurable,
+        restoredEnumerable: restoredDescriptor?.enumerable,
+        expectedEnumerable: initialDescriptor.enumerable,
+      };
+    } finally {
+      Object.defineProperty(proto, "focus", initialDescriptor);
+    }
+  });
+
+  expect(result.getterCalls).toBe(2);
+  expect(result.programmaticFocus).toEqual([true, false]);
+  expect(result.restoredGetter).toBe(true);
+  expect(result.restoredSetter).toBeUndefined();
+  expect(result.restoredConfigurable).toBe(true);
+  expect(result.restoredEnumerable).toBe(result.expectedEnumerable);
+});
 
 // Verifies that `createKeyborg` interoperates with a foreign `__keyborg.core`
 // using a property-accessor `isNavigatingWithKeyboard` and a `dispose()`

--- a/tests/core-back-compat.stories.tsx
+++ b/tests/core-back-compat.stories.tsx
@@ -5,11 +5,12 @@
 
 import * as React from "react";
 
-import { createKeyborg, disposeKeyborg } from "../src/index.mts";
+import { createKeyborg, disposeKeyborg, nativeFocus } from "../src/index.mts";
 
 interface WindowWithKeyborgFactory extends Window {
   createKeyborg?: typeof createKeyborg;
   disposeKeyborg?: typeof disposeKeyborg;
+  nativeFocus?: typeof nativeFocus;
 }
 
 const meta = { title: "Core Back Compat" };
@@ -20,5 +21,6 @@ export default meta;
 export const Default = () => {
   (window as WindowWithKeyborgFactory).createKeyborg = createKeyborg;
   (window as WindowWithKeyborgFactory).disposeKeyborg = disposeKeyborg;
+  (window as WindowWithKeyborgFactory).nativeFocus = nativeFocus;
   return <div data-testid="fixture">core back compat fixture</div>;
 };


### PR DESCRIPTION
## Summary

- wrap `HTMLElement.prototype.focus` with `Object.defineProperty` without invoking accessor getters on the prototype
- invoke getter-backed native focus methods with the focused element as `this`
- restore the complete original descriptor during disposal
- remove the Storybook compatibility workaround and add regression coverage for programmatic/native focus behavior

Closes #227

## Validation

- `yarn lint`
- `yarn format`
- `yarn build`
- `yarn test` (15 passed)